### PR TITLE
Fix dataset loading path issue

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -52,12 +52,12 @@ def read_root():
     return {"message": "Fine-tuning framework API"}
 
 @app.get("/available-datasets/")
-def get_available_datasets(base_dir: str = "/workspace"):
+def get_available_datasets(base_dir: str = "./datasets"):
     """
     Get a list of available datasets in the specified directory.
 
     Args:
-        base_dir (str): Base directory to search for datasets. Defaults to "/workspace".
+        base_dir (str): Base directory to search for datasets. Defaults to "./datasets".
 
     Returns:
         Dict[str, List[str]]: Status and list of dataset paths.

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -99,17 +99,35 @@
     <script>
         async function loadDatasets() {
             try {
-                // Hardcode the FineTome dataset for now
+                // Load available datasets from the API
                 const datasetSelect = document.getElementById('datasetSelect');
                 datasetSelect.innerHTML = '';
 
-                // Add FineTome-100k dataset option
-                const fineTomeOption = document.createElement('option');
-                fineTomeOption.value = '/workspace/FineTome-100k';
-                fineTomeOption.textContent = 'FineTome-100k';
-                datasetSelect.appendChild(fineTomeOption);
+                // Call the backend API to get available datasets
+                const response = await fetch(`/available-datasets/`);
+                const data = await response.json();
 
-                return true;
+                if (data.status === 'success' && Array.isArray(data.datasets)) {
+                    // Add a default option
+                    const defaultOption = document.createElement('option');
+                    defaultOption.value = '';
+                    defaultOption.textContent = 'Select a dataset...';
+                    defaultOption.disabled = true;
+                    defaultOption.selected = true;
+                    datasetSelect.appendChild(defaultOption);
+
+                    // Add all available datasets to the dropdown
+                    data.datasets.forEach(datasetPath => {
+                        const option = document.createElement('option');
+                        option.value = datasetPath;
+                        option.textContent = datasetPath.split('/').pop(); // Use directory name as display text
+                        datasetSelect.appendChild(option);
+                    });
+
+                    return true;
+                } else {
+                    throw new Error(data.message || 'Failed to load datasets');
+                }
             } catch (error) {
                 console.error('Error loading datasets:', error);
                 document.getElementById('datasetStatus').textContent = `Error: ${error.message}`;


### PR DESCRIPTION
This PR fixes the issue where the dataset loading dropdown was pointing to a hardcoded absolute path (`/workspace/FineTome-100k`) instead of using relative paths.

### Changes made:
1. **Frontend changes**: Modified `index.html` to dynamically load datasets from the `/available-datasets/` API endpoint instead of using hardcoded dataset options
2. **Backend changes**: Updated the `get_available_datasets()` function in `app.py` to scan `./datasets` directory by default instead of `/workspace`
3. **API improvements**: The available-datasets endpoint now scans for datasets in a relative path and returns all found datasets

### Benefits:
- Dataset paths are now relative to the application location
- Users can place datasets in a `./datasets` folder relative to the application
- More flexible dataset management without hardcoded paths
- Better portability across different environments

This change addresses the issue described in #2 where the dataset loading dropdown was pointing to the wrong folder.