### PR TITLE
Fix Setup Training button 405 error

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -441,7 +441,7 @@ def train_model(request: TrainingRequest):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@app.post("/setup-training/")
+@app.get("/setup-training/")
 def setup_training(output_dir: str = "outputs", max_steps: int = 30):
     """
     Set up the training configuration.


### PR DESCRIPTION

This PR fixes the issue where the "Setup Training" button was returning a 405 Method Not Allowed error.

The frontend was making a GET request to `/setup-training/` with query parameters, but the backend endpoint was defined as POST. This mismatch caused the 405 error.

Changes made:
1. Changed the `@app.post("/setup-training/")` endpoint to `@app.get("/setup-training/")` in `web/app.py`
2. Kept all other functionality intact

This fix allows the frontend to successfully communicate with the backend when setting up training configurations.
